### PR TITLE
add epsilon maps

### DIFF
--- a/src/conftest.py
+++ b/src/conftest.py
@@ -19,7 +19,7 @@ def mock_state():
 
 @pytest.fixture
 def mock_env(mock_state: State):
-    return make_env(initial_state=mock_state, epsilon=0.1, memory=False, changeable_features=[0])
+    return make_env(initial_state=mock_state, epsilon=None, memory=False)
 
 
 @pytest.fixture

--- a/src/dynamics/registration.py
+++ b/src/dynamics/registration.py
@@ -25,7 +25,7 @@ E = TypeVar("E", bound=type[EnvCreator])
 
 @beartype
 def make_env(
-    *, initial_state: State, epsilon: float, memory: bool, changeable_features: list[int]
+    *, initial_state: State, epsilon: dict[int, float], memory: bool, changeable_features: list[int]
 ) -> gymnasium.Env[StateDict, npt.NDArray[np.float64]]:
     from src.dynamics.registration import CreditEnvCreator
 
@@ -114,7 +114,7 @@ class CreditEnvCreator:
         del kwargs
         initial_state = unwrap_or(initial_state, default=CreditData().as_state())
         reward_fn = unwrap_or(reward_fn, default=LogisticReward(l2_penalty=0.0))
-        response_fn = unwrap_or(response_fn, default=LinearResponse(epsilon=1.0))
+        response_fn = unwrap_or(response_fn, default=LinearResponse(epsilon=None))
         simulator = Simulator(
             response=response_fn,
             memory=memory,

--- a/src/dynamics/registration.py
+++ b/src/dynamics/registration.py
@@ -25,11 +25,11 @@ E = TypeVar("E", bound=type[EnvCreator])
 
 @beartype
 def make_env(
-    *, initial_state: State, epsilon: dict[int, float], memory: bool, changeable_features: list[int]
+    *, initial_state: State, epsilon: dict[int, float], memory: bool
 ) -> gymnasium.Env[StateDict, npt.NDArray[np.float64]]:
     from src.dynamics.registration import CreditEnvCreator
 
-    response_fn = LinearResponse(epsilon=epsilon, changeable_features=changeable_features)
+    response_fn = LinearResponse(epsilon=epsilon)
     env = CreditEnvCreator.as_env(
         initial_state=initial_state, response_fn=response_fn, memory=memory
     )

--- a/src/dynamics/registration.py
+++ b/src/dynamics/registration.py
@@ -25,11 +25,14 @@ E = TypeVar("E", bound=type[EnvCreator])
 
 @beartype
 def make_env(
-    *, initial_state: State, epsilon: dict[int, float], memory: bool
+    *, initial_state: State, epsilon: dict[int, float] | None, memory: bool
 ) -> gymnasium.Env[StateDict, npt.NDArray[np.float64]]:
     from src.dynamics.registration import CreditEnvCreator
 
-    response_fn = LinearResponse(epsilon=epsilon)
+    new_epsilon = unwrap_or(
+        epsilon, default={a: 0.0 for a in range(initial_state.features.shape[1])}
+    )
+    response_fn = LinearResponse(epsilon=new_epsilon)
     env = CreditEnvCreator.as_env(
         initial_state=initial_state, response_fn=response_fn, memory=memory
     )

--- a/src/dynamics/response.py
+++ b/src/dynamics/response.py
@@ -33,7 +33,7 @@ class LinearResponse(Response):
                 "'action' should correspond to the feature weights and thus must have entries "
                 "numbering the number of columns in 'features'"
             )
-        epsilon_map = unwrap_or(self.epsilon, default={a: 1 for a in range(len(features))})
+        epsilon_map = unwrap_or(self.epsilon, default={a: 0 for a in range(features.shape[1])})
         new_features = np.copy(features)
 
         neg_item_mask = np.dot(action[None, :], features[...].T)[0] < 0
@@ -42,60 +42,6 @@ class LinearResponse(Response):
                 weight / np.linalg.norm(action)
             ) * action[feature]
         return new_features
-
-
-@beartype
-def rir_response(
-    *,
-    features: FloatArray,
-    action: FloatArray,
-    epsilon: float = 1.0,
-    changeable_features: IntArray | slice | list[int] | None = None,
-) -> FloatArray:
-    r"""
-    Respond with the Resample-If-Rejected (RIR) procedure proposed in
-    `Performative Prediction with Neural Networks` wherein the strategic
-    features of a given simple are replaced with the strategic features
-    of another sample with probability equal to the classifier's
-    probabilities plus some performative hyperparameter, \epsilon.
-
-    .. _Performative Prediction with Neural Networks:
-        https://proceedings.mlr.press/v206/mofakhami23a.html
-
-    .. note::
-        The incoming predictions (actions) are presumed to lie in the
-        interval [0, 1] (i.e. be valid probabilities).
-    """
-    n = features.shape[0]
-    resample_inds = np.random.default_rng(0).binomial(n=1, p=(action + epsilon).clip(max=1.0))
-    # sample new indices by shifting by x ~ unif{1, n-1} and projecting the image
-    # onto the Z/nZ ring.
-    shift = np.random.default_rng(0).integers(
-        low=1,
-        high=n,
-        size=(
-            len(
-                resample_inds,
-            ),
-        ),
-    )
-    transplant_inds = (resample_inds + shift) % n
-
-    changeable_features = unwrap_or(changeable_features, default=slice(None))
-    if isinstance(changeable_features, list):
-        changeable_features = np.array(changeable_features)
-    # Add broadcasting dimensions in event that the strategic-feature indices
-    # are encoded by a numpy array (or by a list-turned-array)
-    if isinstance(changeable_features, np.ndarray):
-        resample_inds = resample_inds[:, None]
-        transplant_inds = transplant_inds[:, None]
-        changeable_features = changeable_features[None]
-
-    new_strategic_features = features[transplant_inds, changeable_features]
-    new_features = np.copy(features)
-    new_features[resample_inds, changeable_features] = new_strategic_features
-
-    return new_features
 
 
 @beartype
@@ -116,8 +62,7 @@ class RIRResponse:
         interval [0, 1] (i.e. be valid probabilities).
     """
 
-    changeable_features: IntArray | slice | list[int] | None = None
-    epsilon: float = 1.0
+    epsilon: dict[int, float] | None = None
 
     def __call__(
         self,
@@ -125,9 +70,57 @@ class RIRResponse:
         features: FloatArray,
         action: FloatArray,
     ) -> FloatArray:
-        return rir_response(
+        epsilon_map = unwrap_or(self.epsilon, default={a: 1.0 for a in range(len(features))})
+        return self.rir_response(
             features=features,
             action=action,
-            epsilon=self.epsilon,
-            changeable_features=self.changeable_features,
+            epsilon=epsilon_map,
         )
+
+    @beartype
+    def rir_response(
+        self,
+        *,
+        features: FloatArray,
+        action: FloatArray,
+        epsilon: dict[int, float],
+    ) -> FloatArray:
+        r"""
+        Respond with the Resample-If-Rejected (RIR) procedure proposed in
+        `Performative Prediction with Neural Networks` wherein the strategic
+        features of a given simple are replaced with the strategic features
+        of another sample with probability equal to the classifier's
+        probabilities plus some performative hyperparameter, \epsilon.
+
+        .. _Performative Prediction with Neural Networks:
+            https://proceedings.mlr.press/v206/mofakhami23a.html
+
+        .. note::
+            The incoming predictions (actions) are presumed to lie in the
+            interval [0, 1] (i.e. be valid probabilities).
+        """
+        n = features.shape[0]
+        modified_action = action.copy()
+        for i in range(len(action)):
+            modified_action[i] += epsilon.get(i, 0)
+        resample_inds = np.random.default_rng(0).binomial(n=1, p=modified_action.clip(max=1.0))
+        # sample new indices by shifting by x ~ unif{1, n-1} and projecting the image
+        # onto the Z/nZ ring.
+        shift = np.random.default_rng(0).integers(
+            low=1,
+            high=n,
+            size=(
+                len(
+                    resample_inds,
+                ),
+            ),
+        )
+        transplant_inds = (resample_inds + shift) % n
+
+        new_strategic_features = features[transplant_inds, np.array(list(epsilon.keys()))[:, None]]
+        new_features = np.copy(features)
+        new_features[resample_inds, np.array(list(epsilon.keys()))[:, None]] = (
+            new_strategic_features
+        )
+
+        return new_features

--- a/src/dynamics/response.py
+++ b/src/dynamics/response.py
@@ -5,7 +5,7 @@ from beartype import beartype
 import numpy as np
 from ranzen import unwrap_or
 
-from src.types import FloatArray, IntArray
+from src.types import FloatArray
 
 __all__ = ["Response", "LinearResponse"]
 

--- a/src/dynamics/response.py
+++ b/src/dynamics/response.py
@@ -70,7 +70,7 @@ class RIRResponse:
         features: FloatArray,
         action: FloatArray,
     ) -> FloatArray:
-        epsilon_map = unwrap_or(self.epsilon, default={a: 1.0 for a in range(len(features))})
+        epsilon_map = unwrap_or(self.epsilon, default={a: 0.0 for a in range(features.shape[1])})
         return self.rir_response(
             features=features,
             action=action,

--- a/src/dynamics/response.py
+++ b/src/dynamics/response.py
@@ -38,6 +38,8 @@ class LinearResponse(Response):
 
         neg_item_mask = np.dot(action[None, :], features[...].T)[0] < 0
         for feature, weight in epsilon_map.items():
+            # TODO: Make a decision on the normalisation.
+            # In Perdomo et al this is not present, but some sort of normalisation (not neccessarily this) might make sense.
             new_features[np.nonzero(neg_item_mask), feature] += (
                 weight / np.linalg.norm(action)
             ) * action[feature]

--- a/src/loader/credit.py
+++ b/src/loader/credit.py
@@ -33,7 +33,24 @@ class Data(Protocol):
 
 @beartype
 class CreditData:
-    """Class to lazily load the credit dataset."""
+    """Class to lazily load the credit dataset.
+
+    Features: {
+        0: RevolvingUtilizationOfUnsecuredLines,
+        1: age,
+        2: NumberOfTime30-59DaysPastDueNotWorse,
+        3: DebtRatio,
+        4: MonthlyIncome,
+        5: NumberOfOpenCreditLinesAndLoans,
+        6: NumberOfTimes90DaysLate,
+        7: NumberRealEstateLoansOrLines,
+        8: NumberRealEstateLoansOrLines,
+        9: NumberOfDependents,
+        10: Bias term (added by the framework)
+    }
+
+    Changeable features in performative prediction paper: [0, 5, 7]
+    """
 
     def __init__(self, seed: int | None = None) -> None:
         self.filepath = (Path(__file__).parent / "credit_data").with_suffix(".zip")

--- a/src/plotting.py
+++ b/src/plotting.py
@@ -118,9 +118,9 @@ def make_feature_weight_plot(
     theta = np.stack(thetas, axis=1)
     for i in range(theta.shape[0] - include_bias):
         if i in epsilon and epsilon[i] > 0:
-            ax.plot(abs(theta[i]), label=f"{i}", linestyle="dashed")
-        else:
             ax.plot(abs(theta[i]), label=f"{i}*")
+        else:
+            ax.plot(abs(theta[i]), label=f"{i}", linestyle="dashed")
 
     ax.set_xlabel("Step")
     ax.set_ylabel("Weight")

--- a/src/plotting.py
+++ b/src/plotting.py
@@ -106,7 +106,6 @@ def make_feature_weight_plot(
     *,
     epsilon: dict[int, float],
     thetas: list[npt.NDArray[np.float64]],
-    changeable_features: list[int],
     show_bias: bool,
     out_dir: Path,
 ):
@@ -118,10 +117,10 @@ def make_feature_weight_plot(
     ax.set_title(rf"Feature importance, $\epsilon$={epsilon}")
     theta = np.stack(thetas, axis=1)
     for i in range(theta.shape[0] - include_bias):
-        if i in changeable_features:
-            ax.plot(abs(theta[i]), label=f"{i}*")
-        if i not in changeable_features:
+        if i in epsilon and epsilon[i] > 0:
             ax.plot(abs(theta[i]), label=f"{i}", linestyle="dashed")
+        else:
+            ax.plot(abs(theta[i]), label=f"{i}*")
 
     ax.set_xlabel("Step")
     ax.set_ylabel("Weight")

--- a/src/plotting.py
+++ b/src/plotting.py
@@ -1,137 +1,134 @@
+from pathlib import Path
+
 from matplotlib import pyplot as plt
 import numpy as np
+import numpy.typing as npt
 
 
 def make_risk_plots(
     *,
-    epsilon_list: list[float | int],
+    epsilon: dict[int, float],
     num_steps: int,
-    loss_starts: list[list[float]],
-    loss_ends: list[list[float]],
+    loss_starts: list[float],
+    loss_ends: list[float],
+    out_dir: Path,
 ):
     # ------------------------------------------------------------------------------
     # Plotting
     # ------------------------------------------------------------------------------
-    _, axes = plt.subplots(nrows=2, ncols=2, figsize=(16, 12))
+    _, ax = plt.subplots(figsize=(16, 12))
     offset = 0.8
     # We plot the risk at the beginning and at the end of each round, connecting
     # the two values with a blue line and indicating change in risk due to
     # strategic distribution shift with a dashed green line.
-    for idx, epsilon in enumerate(epsilon_list):
-        ax = axes[idx // 2][idx % 2]  # type: ignore
-        ax.set_title(rf"Performative Risk, $\epsilon$={epsilon}", fontsize=20)
-        for i in range(2, num_steps):
-            ax.plot([i, i + offset], [loss_starts[idx][i], loss_ends[idx][i]], "b*-")
-            if i < num_steps - 1:
-                ax.plot(
-                    [i + offset, i + 1],
-                    [loss_ends[idx][i], loss_starts[idx][i + 1]],
-                    "g--",
-                )
 
-        ax.set_xlabel("Step", fontsize=16)
-        ax.set_ylabel("Loss", fontsize=16)
-        ax.set_yscale("log")
+    ax.set_title(rf"Performative Risk, $\epsilon$={epsilon}", fontsize=20)
+    for i in range(2, num_steps):
+        ax.plot([i, i + offset], [loss_starts[i], loss_ends[i]], "b*-")
+        if i < num_steps - 1:
+            ax.plot(
+                [i + offset, i + 1],
+                [loss_ends[i], loss_starts[i + 1]],
+                "g--",
+            )
+
+    ax.set_xlabel("Step", fontsize=16)
+    ax.set_ylabel("Loss", fontsize=16)
+    ax.set_yscale("log")
 
     plt.subplots_adjust(hspace=0.25)
-    plt.show()
+
+    # Save the plot
+    plot_path = out_dir / "risk_plot.png"
+    plt.savefig(plot_path)
+    plt.close()
 
 
 def make_acc_plots(
     *,
-    epsilon_list: list[float | int],
+    epsilon: dict[int, float],
     num_steps: int,
-    acc_starts: list[list[float]],
-    acc_ends: list[list[float]],
+    acc_starts: list[float],
+    acc_ends: list[float],
+    out_dir: Path,
 ):
-    _, axes = plt.subplots(nrows=2, ncols=2, figsize=(16, 12))
+    _, ax = plt.subplots(figsize=(16, 12))
     offset = 0.8
     # The performative risk is a surrogate for the underlying metric we care
     # about, accuracy. We can similarly plot accuracy during retraining.
-    for idx, epsilon in enumerate(epsilon_list):
-        ax = axes[idx // 2][idx % 2]  # type: ignore
-        ax.set_title(rf"Performative Accuracy, $\epsilon$={epsilon}", fontsize=20)
-        for i in range(2, num_steps):
-            ax.plot([i, i + offset], [acc_starts[idx][i], acc_ends[idx][i]], "b*-")
-            if i < num_steps - 1:
-                ax.plot(
-                    [i + offset, i + 1],
-                    [acc_ends[idx][i], acc_starts[idx][i + 1]],
-                    "g--",
-                )
 
-        ax.set_xlabel("Step", fontsize=16)
-        ax.set_ylabel("Accuracy", fontsize=16)
-        # ax.set_ylim([0.5, 0.75])
+    ax.set_title(rf"Performative Accuracy, $\epsilon$={epsilon}", fontsize=20)
+    for i in range(2, num_steps):
+        ax.plot([i, i + offset], [acc_starts[i], acc_ends[i]], "b*-")
+        if i < num_steps - 1:
+            ax.plot(
+                [i + offset, i + 1],
+                [acc_ends[i], acc_starts[i + 1]],
+                "g--",
+            )
+
+    ax.set_xlabel("Step", fontsize=16)
+    ax.set_ylabel("Accuracy", fontsize=16)
+    # ax.set_ylim([0.5, 0.75])
     plt.subplots_adjust(hspace=0.25)
-    plt.show()
+    # Save the plot
+    plot_path = out_dir / "acc_plot.png"
+    plt.savefig(plot_path)
+    plt.close()
 
 
 def make_gap_plots(
     *,
-    epsilon_list: list[float | int],
-    theta_gaps: list[list[float]],
+    epsilon: dict[int, float],
+    theta_gaps: list[float],
+    out_dir: Path,
 ):
-    processed_theta_gaps = [[x for x in tg if x > 0.0 or x < 0.0] for tg in theta_gaps]
+    processed_theta_gaps = [x for x in theta_gaps if x > 0.0 or x < 0.0]
     _, ax = plt.subplots(figsize=(10, 8))
 
     # Finally, we plot the distance between consecutive iterates. This is the
     # quantity bounded by the theorems in Performative Prediction, which shows
     # that repeated risk minimization converges in domain to a stable point.
-    for idx, (gaps, eps) in enumerate(zip(processed_theta_gaps, epsilon_list)):
-        label = f"$\\varepsilon$ = {eps}"
-        if idx == 0:
-            ax.semilogy(
-                gaps,
-                label=label,
-                linewidth=3,
-                alpha=1,
-                marker="*",
-                linestyle=(0, (1, 1)),
-            )
-        elif idx == 1:
-            ax.semilogy(
-                gaps,
-                label=label,
-                linewidth=3,
-                alpha=1,
-                marker="*",
-                linestyle="solid",
-            )
-        else:
-            ax.semilogy(gaps, label=label, linewidth=3)
+    label = f"$\\varepsilon$ = {epsilon}"
+    ax.semilogy(processed_theta_gaps, label=label, linewidth=3)
     ax.set_title("Convergence in Domain for Repeated Risk Minimization", fontsize=18)
     ax.set_xlabel("Iteration $t$", fontsize=18)
     ax.set_ylabel(r"Distance Between Iterates: $\|\theta_{t+1} - \theta_{t}\|_2 $", fontsize=14)
     ax.tick_params(labelsize=18)
     plt.legend(fontsize=18)
-    plt.show()
+    # Save the plot
+    plot_path = out_dir / "gap_plot.png"
+    plt.savefig(plot_path)
+    plt.close()
 
 
 def make_feature_weight_plot(
     *,
-    epsilon_list: list[float | int],
-    thetas: list[list[np.ndarray]],
+    epsilon: dict[int, float],
+    thetas: list[npt.NDArray[np.float64]],
     changeable_features: list[int],
     show_bias: bool,
+    out_dir: Path,
 ):
-    _, axes = plt.subplots(nrows=2, ncols=2, figsize=(12, 8))
+    _, ax = plt.subplots(figsize=(12, 8))
     # The performative risk is a surrogate for the underlying metric we care
     # about, accuracy. We can similarly plot accuracy during retraining.
     include_bias = 0 if show_bias else 1
-    for idx, epsilon in enumerate(epsilon_list):
-        ax = axes[idx // 2][idx % 2]  # type: ignore
-        ax.set_title(rf"Feature importance, $\epsilon$={epsilon}")
-        theta = np.stack(thetas[idx], axis=1)
-        for i in range(theta.shape[0] - include_bias):
-            if i in changeable_features:
-                ax.plot(abs(theta[i]), label=f"{i}*")
-            if i not in changeable_features:
-                ax.plot(abs(theta[i]), label=f"{i}", linestyle="dashed")
 
-        ax.set_xlabel("Step")
-        ax.set_ylabel("Weight")
-        ax.legend(loc="center right")
-        # ax.set_ylim([0.5, 0.75])
+    ax.set_title(rf"Feature importance, $\epsilon$={epsilon}")
+    theta = np.stack(thetas, axis=1)
+    for i in range(theta.shape[0] - include_bias):
+        if i in changeable_features:
+            ax.plot(abs(theta[i]), label=f"{i}*")
+        if i not in changeable_features:
+            ax.plot(abs(theta[i]), label=f"{i}", linestyle="dashed")
+
+    ax.set_xlabel("Step")
+    ax.set_ylabel("Weight")
+    ax.legend(loc="center right")
+    # ax.set_ylim([0.5, 0.75])
     plt.subplots_adjust(hspace=0.25)
-    plt.show()
+    # Save the plot
+    plot_path = out_dir / "feature_weight_plot.png"
+    plt.savefig(plot_path)
+    plt.close()

--- a/src/repeated_risk_min.py
+++ b/src/repeated_risk_min.py
@@ -19,7 +19,7 @@ class EpisodeRecord:
     acc_start: list[float]
     acc_end: list[float]
     theta_gap: list[float]
-    theta: list[np.ndarray]
+    theta: list[npt.NDArray[np.float64]]
 
 
 @beartype

--- a/src/rrm_credit_lr.py
+++ b/src/rrm_credit_lr.py
@@ -18,7 +18,6 @@ class ExperimentSettings:
     memory: bool
     num_steps: int
     epsilons: dict[int, float]
-    changeable_features: list[int]
 
 
 @dataclass
@@ -35,16 +34,15 @@ exp_store(
     ExperimentSettings,
     memory=False,
     num_steps=10,
-    epsilons={a: 1 for a in range(10)},
-    changeable_features=[2, 6, 8],
+    epsilons={i: 0 if i in [2, 6, 8] else 1 for i in range(10)},
     name="base",
 )
+
 exp_store(
     ExperimentSettings,
     memory=False,
     num_steps=10,
-    epsilons={a: 1 for a in range(10)},
-    changeable_features=[0, 5, 7],
+    epsilons={i: 0 if i in [0, 5, 7] else 1 for i in range(10)},
     name="paper",
 )
 
@@ -91,13 +89,11 @@ def main(dataset: Data, experiment: ExperimentSettings, model: Model, plot: Plot
         initial_state=initial_state,
         epsilon=dict(experiment.epsilons),
         memory=experiment.memory,
-        changeable_features=list(experiment.changeable_features),
     )
     record = repeated_risk_minimization(
         env=env, lr=lr, num_steps=experiment.num_steps, l2_penalty=model.l2_penalty
     )
 
-    changeable_features = env.simulator.response.changeable_features  # type: ignore
     out_dir = Path(hydra.core.hydra_config.HydraConfig.get().runtime.output_dir)  # type: ignore
     make_risk_plots(
         epsilon=experiment.epsilons,
@@ -117,7 +113,6 @@ def main(dataset: Data, experiment: ExperimentSettings, model: Model, plot: Plot
     make_feature_weight_plot(
         epsilon=experiment.epsilons,
         thetas=record.theta,
-        changeable_features=changeable_features,
         show_bias=plot.show_bias,
         out_dir=out_dir,
     )

--- a/src/rrm_credit_lr.py
+++ b/src/rrm_credit_lr.py
@@ -34,7 +34,7 @@ exp_store(
     ExperimentSettings,
     memory=False,
     num_steps=10,
-    epsilons={i: 0 if i in [2, 6, 8] else 1 for i in range(10)},
+    epsilons={i: 1.0 for i in [2, 6, 8]},
     name="base",
 )
 
@@ -42,7 +42,7 @@ exp_store(
     ExperimentSettings,
     memory=False,
     num_steps=10,
-    epsilons={i: 0 if i in [0, 5, 7] else 1 for i in range(10)},
+    epsilons={i: 1.0 for i in [0, 5, 7]},
     name="paper",
 )
 

--- a/src/rrm_credit_lr.py
+++ b/src/rrm_credit_lr.py
@@ -1,10 +1,10 @@
 from __future__ import annotations
 from dataclasses import dataclass
+from pathlib import Path
 
+import hydra
 from hydra_zen import ZenStore, zen
 from loguru import logger
-from numpy import typing as npt
-from tqdm import tqdm
 
 from src.dynamics.registration import make_env
 from src.loader.credit import CreditData, Data
@@ -17,7 +17,7 @@ from src.repeated_risk_min import repeated_risk_minimization
 class ExperimentSettings:
     memory: bool
     num_steps: int
-    epsilons: list[float]
+    epsilons: dict[int, float]
     changeable_features: list[int]
 
 
@@ -35,9 +35,17 @@ exp_store(
     ExperimentSettings,
     memory=False,
     num_steps=10,
-    epsilons=[1, 10, 100, 1000],
+    epsilons={a: 1 for a in range(10)},
     changeable_features=[2, 6, 8],
     name="base",
+)
+exp_store(
+    ExperimentSettings,
+    memory=False,
+    num_steps=10,
+    epsilons={a: 1 for a in range(10)},
+    changeable_features=[0, 5, 7],
+    name="paper",
 )
 
 model_store = store(group="model")
@@ -58,7 +66,7 @@ plot_store(PlotSettings, show_bias=True, name="base")
     ],
 )
 def main(dataset: Data, experiment: ExperimentSettings, model: Model, plot: PlotSettings):
-    assert len(experiment.epsilons) == 4, "For plotting reasons, the number of epsilons must be 4"
+    """To update the cost mapping, use `+` syntax as dicts are merged in hydra."""
 
     # We use the credit simulator, which is a strategic classification
     # simulator based on the 'Kaggle Give Me Some Credit' (GMSC) dataset.
@@ -70,59 +78,48 @@ def main(dataset: Data, experiment: ExperimentSettings, model: Model, plot: Plot
     base_x, base_y = initial_state.features, initial_state.labels
     num_agents, num_features = base_x.shape
     logger.info(f"The dataset is made up of {num_agents} agents and {num_features} features.")
+
     # Fit a rudimentary LR model to the data.
-    # l2_penalty = 1.0 / num_agents # Commented this out, but not deleting yet
+    lr = model.fit(
+        x=base_x,
+        y=base_y,
+    )
+    baseline_acc = lr.acc(features=base_x, labels=base_y)
+    logger.info(f"Baseline logistic regresion model accuracy: {100 * baseline_acc:.2f}%")
 
-    loss_starts: list[list[float]] = []
-    acc_starts: list[list[float]] = []
-    loss_ends: list[list[float]] = []
-    acc_ends: list[list[float]] = []
-    theta_gaps: list[list[float]] = []
-    thetas: list[list[npt.NDArray]] = []
-
-    for epsilon in tqdm(experiment.epsilons):
-        lr = model.fit(
-            x=base_x,
-            y=base_y,
-        )
-        baseline_acc = lr.acc(features=base_x, labels=base_y)
-        logger.info(f"Baseline logistic regresion model accuracy: {100 * baseline_acc:.2f}%")
-        env = make_env(
-            initial_state=initial_state,
-            epsilon=epsilon,
-            memory=experiment.memory,
-            changeable_features=list(experiment.changeable_features),
-        )
-        logger.info(f"Running retraining for epsilon {epsilon:.2f}")
-        record = repeated_risk_minimization(
-            env=env, lr=lr, num_steps=experiment.num_steps, l2_penalty=model.l2_penalty
-        )
-        loss_starts.append(record.loss_start)
-        loss_ends.append(record.loss_end)
-        acc_starts.append(record.acc_start)
-        acc_ends.append(record.acc_end)
-        theta_gaps.append(record.theta_gap)
-        thetas.append(record.theta)
+    env = make_env(
+        initial_state=initial_state,
+        epsilon=dict(experiment.epsilons),
+        memory=experiment.memory,
+        changeable_features=list(experiment.changeable_features),
+    )
+    record = repeated_risk_minimization(
+        env=env, lr=lr, num_steps=experiment.num_steps, l2_penalty=model.l2_penalty
+    )
 
     changeable_features = env.simulator.response.changeable_features  # type: ignore
+    out_dir = Path(hydra.core.hydra_config.HydraConfig.get().runtime.output_dir)  # type: ignore
     make_risk_plots(
-        epsilon_list=experiment.epsilons,
+        epsilon=experiment.epsilons,
         num_steps=experiment.num_steps,
-        loss_starts=loss_starts,
-        loss_ends=loss_ends,
+        loss_starts=record.loss_start,
+        loss_ends=record.loss_end,
+        out_dir=out_dir,
     )
     make_acc_plots(
-        epsilon_list=experiment.epsilons,
+        epsilon=experiment.epsilons,
         num_steps=experiment.num_steps,
-        acc_starts=acc_starts,
-        acc_ends=acc_ends,
+        acc_starts=record.acc_start,
+        acc_ends=record.acc_end,
+        out_dir=out_dir,
     )
-    make_gap_plots(epsilon_list=experiment.epsilons, theta_gaps=theta_gaps)
+    make_gap_plots(epsilon=experiment.epsilons, theta_gaps=record.theta_gap, out_dir=out_dir)
     make_feature_weight_plot(
-        epsilon_list=experiment.epsilons,
-        thetas=thetas,
+        epsilon=experiment.epsilons,
+        thetas=record.theta,
         changeable_features=changeable_features,
         show_bias=plot.show_bias,
+        out_dir=out_dir,
     )
 
 

--- a/src/tests/test_registration.py
+++ b/src/tests/test_registration.py
@@ -20,15 +20,20 @@ def test_env_registration(memory: bool) -> None:
     assert env.simulator.memory is memory
 
 
-@pytest.mark.parametrize("epsilon, memory", [(0.1, True), (0.0, False), (1.0, True)])
+@pytest.mark.parametrize(
+    "epsilon, memory",
+    [
+        ({a: 0.1 for a in range(2)}, True),
+        ({a: 0.0 for a in range(2)}, False),
+        ({a: 1.0 for a in range(2)}, True),
+    ],
+)
 def test_make_env(
     mock_state: State,  # noqa: F811
-    epsilon: float,
+    epsilon: dict[int, float],
     memory: bool,
 ):
     # Arrange - mock_state fixture provides initial_state
     # Act
-    env = make_env(
-        initial_state=mock_state, epsilon=epsilon, memory=memory, changeable_features=[0]
-    )
+    env = make_env(initial_state=mock_state, epsilon=epsilon, memory=memory)
     assert env is not None

--- a/src/tests/test_response.py
+++ b/src/tests/test_response.py
@@ -11,12 +11,11 @@ def test_linear_response():
     features = rng.normal(loc=0, scale=1, size=(n, c))
     action = rng.normal(loc=0, scale=0.5, size=(c,))
 
-    response_fn = LinearResponse(epsilon=1.0, changeable_features=None)
+    response_fn = LinearResponse(epsilon=None)
     new_features = response_fn.respond(features=features, action=action)
     assert new_features.shape == features.shape
 
-    changeable_features = np.array([0, 2], dtype=np.uint8)
-    response_fn = LinearResponse(epsilon=1.0, changeable_features=changeable_features)
+    response_fn = LinearResponse(epsilon={a: 1.0 for a in range(features.shape[1])})
     new_features = response_fn.respond(features=features, action=action)
     assert new_features.shape == features.shape
 
@@ -32,13 +31,12 @@ def test_rir_response():
     features = rng.integers(low=0, high=4, size=(n, c)).astype(np.float64)
     action = rng.uniform(low=0, high=1, size=(n,))
 
-    response_fn = RIRResponse(epsilon=1.0, changeable_features=None)
+    response_fn = RIRResponse(epsilon={a: 1.0 for a in range(features.shape[1])})
     new_features = response_fn(features=features, action=action)
     with pytest.raises(AssertionError):
         assert np.testing.assert_array_equal(features, new_features)
 
-    changeable_features = np.array([0, 2], dtype=np.uint8)
-    response_fn = RIRResponse(epsilon=1.0, changeable_features=changeable_features)
+    response_fn = RIRResponse(epsilon={a: 1.0 for a in range(features.shape[1])})
     new_features = response_fn(features=features, action=action)
 
     assert new_features.shape == features.shape

--- a/src/tests/test_simulator.py
+++ b/src/tests/test_simulator.py
@@ -9,7 +9,7 @@ from src.dynamics.state import State
 def test_simulator(mock_state: State) -> None:
     action = np.random.default_rng(0).uniform(low=0, high=1, size=(mock_state.num_features,))
     run = Simulator(
-        response=LinearResponse(epsilon=1.0),
+        response=LinearResponse(epsilon={a: 1.0 for a in range(2)}),
         memory=False,
     ).simulate(
         state=mock_state,


### PR DESCRIPTION
This isn't that clever. Epsilon has gone from being a single value to a map of col_id number to float. 
At the same time, we no longer need exactly 4 epsilons for plots, we just do one experiment at a time.
Additionally, instead of `plt.show()`-ing the plots, we save them in the hydra outputs dir for that run (which has the config etc stored as well)